### PR TITLE
Activated the 'tables' options for showdown.js

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -118,7 +118,7 @@ var cachedConverter = null;
 
 function getConverter () {
     if(!cachedConverter) {
-        cachedConverter = new showdown.Converter();
+        cachedConverter = new showdown.Converter({"tables": true});
     }
 
     return cachedConverter;


### PR DESCRIPTION
Hello,

First of all, thank you for creating this plugin.
I noticed the table formatting is not working. This is to the fact that [table formatting is disabled by default on showdown.js](https://github.com/showdownjs/showdown/wiki/Showdown-options#tables). 

Since you mention to either open a new issues or submit a pull request to fix anything we find, here goes...

On Code.gs when instantiating the converter it just needs to have the *tables* option set to *true*.

```javascript
/* on Code.gs */
function getConverter () {
    if(!cachedConverter) {
        // cachedConverter = new showdown.Converter();
        cachedConverter = new showdown.Converter({tables: true});
    }

    return cachedConverter;

    //text      = '#hello, markdown!',
    //html      = converter.makeHtml(text);
}
```

Thank you,
